### PR TITLE
comment on code snippet in book

### DIFF
--- a/chapter2.5/Page 47/code.c
+++ b/chapter2.5/Page 47/code.c
@@ -22,6 +22,7 @@
    find_track(search_for);
    return 0;
  }
+
  int main()
  {
    char search_for[80];


### PR DESCRIPTION
Hi David! 
I am working through your (so far great) book on C (Head First C), and spotted a peculiarity in the code:
in section 2.5, under "It's time for a code review", the code states:

int main()
{
    char search_for[80];
    printf("Search for: ");
    scanf("%79s", search_for);
    search_for[strlen(search_for)-1] = '\0';
    find_track(search_for);
    return 0;
}

where  
    search_for[strlen(search_for)-1] = '\0'
replaces the last inputted character.
should it be 
    search_for[strlen(search_for)] = '\0';
instead?